### PR TITLE
Man page cleanup

### DIFF
--- a/rpfload.1
+++ b/rpfload.1
@@ -33,10 +33,12 @@ loader with automatic rollback
 .Sh DESCRIPTION
 The
 .Nm
-tool uses pfctl to load a PF firewall configuration file and automatically rolls back
+tool uses
+.Xr pfctl 8
+to load a PF firewall configuration file and automatically rolls back
 to a backup configuraton file after a configurable amount of time, if its PID has not been
 killed or Ctrl-C pressed before the timeout period has expired.
-The following options determine behavior: 
+The following options determine behavior:
 .Bl -tag -width Dsssigfile
 .It Fl f Ar live_config
 The PF config file to apply immediately.

--- a/rpfload.1
+++ b/rpfload.1
@@ -17,7 +17,9 @@
 .Os
 .Sh NAME
 .Nm rpfload
-.Nd PF configuration loader with automatic rollback
+.Nd
+.Xr pf.conf 5
+loader with automatic rollback
 .Sh SYNOPSIS
 .Nm rpfload
 .Op Fl o

--- a/rpfload.1
+++ b/rpfload.1
@@ -72,5 +72,5 @@ run 'pfctl -f /etc/pf.conf.backup'.
 This will do the same as the above, but will change the timeout to 30 seconds, and if the configuration
 reverts, it will also overwrite /etc/pf.conf with /etc/pf.conf.backup. 
 .Pp
-.Sh AUTHOR
-Joseph Fierro <joe@kernelpanic.life>
+.Sh AUTHORS
+.An Joseph Fierro Aq Mt joe@kernelpanic.life

--- a/rpfload.1
+++ b/rpfload.1
@@ -52,7 +52,6 @@ When reverting config files, also overwrite the live config file location with t
 The time to wait in seconds before reverting configurations.
 .El
 .Sh EXAMPLES
-.Pp
 A simple example is below:
 .Pp
 .Dl # rpfload -f /etc/pf.conf -d
@@ -73,6 +72,5 @@ run 'pfctl -f /etc/pf.conf.backup'.
 .Pp
 This will do the same as the above, but will change the timeout to 30 seconds, and if the configuration
 reverts, it will also overwrite /etc/pf.conf with /etc/pf.conf.backup. 
-.Pp
 .Sh AUTHORS
 .An Joseph Fierro Aq Mt joe@kernelpanic.life


### PR DESCRIPTION
Tweak some of the mdoc(7) markup based on `mandoc -Tlint` output, and add cross-references to pf.conf(5) and pfctl(8).