### PR TITLE
Add a Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+PROG=	rpfload
+MAN=	rpfload.8
+
+install:
+	install -o root -g bin ${PROG}.pl /usr/local/sbin/${PROG}
+	install -o root -g bin -m 644 ${MAN} /usr/local/man/man8
+	makewhatis /usr/local/man
+
+# check for errors in the manual
+man:
+	mandoc -Tlint ${MAN}

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ so you can check `/var/log/messages` and see exactly which config file it ended 
 
 To install rpfload and its man page, run:
 ```
-# ./install.sh
+# make install
 ```
 
 ### Usage

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-install -m 755 -d /usr/local/sbin
-install -m 755 rpfload.pl /usr/local/sbin/rpfload
-install -m 755 -d /usr/local/man/man8
-install -m 644 rpfload.8 /usr/local/man/man8

--- a/rpfload.8
+++ b/rpfload.8
@@ -43,7 +43,8 @@ The following options determine behavior:
 .It Fl f Ar live_config
 The PF config file to apply immediately.
 .It Fl b Ar backup_config
-The backup PF config file. This will be applied automatically after 60 seconds,
+The backup PF config file.
+This will be applied automatically after 60 seconds,
 or whatever time was chosen with the
 .Fl t
 option.
@@ -70,14 +71,14 @@ A simple example is below:
 .Pp
 .Dl # rpfload -f /etc/pf.conf -d
 .Pp
-This will instruct 
+This will instruct
 .Nm
 to run 'pfctl -f /etc/pf.conf' to load the
 .Pa /etc/pf.conf
 ruleset, wait 60 seconds, and disable the firewall if the
 process has not been terminated before the timeout is reached.
 .Pp
-.Dl # rpfload -f /etc/pf.conf -b /etc/pf.conf.backup 
+.Dl # rpfload -f /etc/pf.conf -b /etc/pf.conf.backup
 .Pp
 This will run instruct
 .Nm


### PR DESCRIPTION
This one is up to your discretion - feel free to reject this idea.

I think makefiles are more along the lines of the "OpenBSD way" than installer scripts, and transforming the shell script into a useful makefile was quite easy. This allows users to install with a possibly more familiar `make install` command.

Also, man(1) likes to complain if you install a man page without running makewhatis(8), so that has been added to the installation steps as well.

Lastly, I also added a target so you can `make man` and see if mandoc(1) generates any warnings about the manual.